### PR TITLE
Gordonwatts/pr_understand_af_failures

### DIFF
--- a/.github/workflows/daily_servicex_uproot_test_af.yml
+++ b/.github/workflows/daily_servicex_uproot_test_af.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/daily_servicex_uproot_test_af.yml
+++ b/.github/workflows/daily_servicex_uproot_test_af.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/daily_servicex_uproot_test_af.yml
+++ b/.github/workflows/daily_servicex_uproot_test_af.yml
@@ -26,6 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip list
       - name: Execute Uproot tests
         env:
           TOKEN: ${{ secrets.SECRET_AF_UPROOT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 kube/ign*
 .idea/
 river-dashboard-values.yaml
+servicex.yaml

--- a/test_uproot.sh
+++ b/test_uproot.sh
@@ -1,6 +1,6 @@
 # A simple shell script that will generate a servicex.yaml file and automatically run it, primarily meant for GitHub actions.
 # David Liu, 21 September 2020, Seattle, WA.
 
-printf "api_endpoints:\n  - endpoint: $2\n    token: $1\n    name: uproot" > ./servicex.yaml
+printf "api_endpoints:\n  - endpoint: $2\n    token: $1\n    name: uproot\n    type: uproot" > ./servicex.yaml
 pytest -s tests/test_uproot_functions.py
 rm ./servicex.yaml


### PR DESCRIPTION
Two changes:

* Add a `type` to the generated `servicex.yaml` file
* Include a `pip list` during the CI so we can see exactly what packages are installed

This fixes only the River AF `uproot` failing test. This is ready for merging.